### PR TITLE
[IGC-231] Pick Unity plugin starting point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.1] - 2025-09-30
+
+### Added
+
+- Changelog!
+  
+### Changed
+
+- Clarified the Readme, converted all inline HTML to markdown.
+- Set shown layers property of the `Capturer` prefab to `Default` so that the plugin captures default objects OOB.
+
+### Fixed 
+
+- Set default `Depth Format` to `16` in the `Capturer` prefab to avoid rendering pipeline errors when this is not set in the game.
+
+## [1.0.0] - 2024-02-24
+
+Starting version tested with Unity 2021 & 2022
+
+[1.0.1]: https://github.com/In-Game-Collectables/igc_unity2021_urp/compare/1.0.0...1.0.1
+[1.0.0]: https://github.com/In-Game-Collectables/igc_unity2021_urp/tree/1.0.0

--- a/CHANGELOG.md.meta
+++ b/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7ec673f25b2255e43bf5b2432f61f83c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Capturer.prefab
+++ b/Capturer.prefab
@@ -50,18 +50,21 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   API_Key: TEST_KEY
-  target: {fileID: 0}
-  MaskerMat: {fileID: 2100000, guid: 478b4b8b6a2d15c4b82ba89e08de0e71, type: 2}
-  depthFormat: 0
   CaptureRadius: 3.5
   FOV: 45
   Frames: 100
   Dimension: 1024
-  HeightOffset: 0.85
   ShownLayers:
-  - Character
+  - Default
   CustomOutputPath: 
+  MaskerMat: {fileID: 2100000, guid: 478b4b8b6a2d15c4b82ba89e08de0e71, type: 2}
+  depthFormat: 16
   CurrentStage: 0
+  Brightness: 1
+  Contrast: 1
+  Saturation: 1
+  GetAllExtraCapturesOnAwake: 0
+  ExtraCaptures: []
 --- !u!114 &5730325559657656804
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -98,7 +101,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a720222bbb98ca545b683ccfb1ea4243, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  TestURL: https://images.dog.ceo/breeds/pinscher-miniature/n02107312_6617.jpg
 --- !u!1 &4464528950513410514
 GameObject:
   m_ObjectHideFlags: 0

--- a/README.md
+++ b/README.md
@@ -1,67 +1,73 @@
 # IGC Unity
-This document is currently a work in progress.
 
-[In Game Collectables](https://www.igc.studio/) Plugin built on Unity version 2021.3.28f1. 
-* Works with URP
-* Tested on version 2022.3.13f1
-* Works on PC and mobile
+[In Game Collectables](https://www.igc.studio/) package for URP, developed under Unity 2021, tested with version 2022, on PC and Mobile platforms. This package includes assets to capture camera transforms and rendered images of a target 3D model and upload the result to the IGC platform.
 
-This plugin will capture renders spun around a character and export out a JSON file of the relative camera transforms. It will upload the necessary files to the IGC API to process to re-create a printable mesh.
+## Usage
 
-<br />
-
-## How to use
 ### Step 1: Set Up
-* Get your API Key from the [IGC Platform](https://platform.igc.studio/collectables)
-* Place *Capturer* Prefab within Scene, positioned at the center of the character to be captured
-* Input your API Key in the *Capturer*'s API_Key parameter
-* Adjust _Capture Radius_ to fit whole character within renders
-* Add all Layers the character is shown on to *Shown Layers*. Hide any other objects in the same layers during capture, or else they can also appear in the final model.
-* Read the [Best Practices](https://github.com/In-Game-Collectables/IGC_Unity2021#best-practices) section for the ideal set up
-### Step 2: Capturing
-* Use function *StartCapture()* within *CharacterCapture.cs* Script to export out all renders/files.
-    * The function has an optional parameter *asyncCapture* that determines if there should be a delay between captures
-        * If *asyncCapture* is false, it may freeze the game up to a couple seconds depending on the dimensions of the renders
-        * *asyncCapture* should NOT be used if the character or lighting can animate/change between frames
-* The event *onCaptureFinish* will be called when Capturing is finished
-* Renders/files will be outputed to *PROJECT_NAME/OUTPUT/Captures/* by default
-* The event *StartCaptureAndUpload()* can be used to combine the steps for Capturing and Uploading
-### Step 3: Uploading
-* Use *UploadCaptures()* within *CharacterCapture.cs* Script. This will upload all images and files within the Captures folder to the API
-    * The event *onUploadSuccess* will be called when the Upload is finished
-    * The event *onUploadFailed* will be called and give a string description on why the Upload has failed
-### Step 4: Checkout
-* After the upload is done, *onUploadSuccess* will be given a URL to the checkout page and a QR Code texture leading to the same page
 
-<br />
+* Get your API Key from the [IGC Platform](https://platform.igc.studio/).
+* Place `Capturer` Prefab within Scene, arrange so that the origin of the prefab is at the centroid of the target model.
+* Configure the capturer prefab:
+    * Set the `API_Key` with the value from the IGC Platform.
+    * Add all the layers that contain the target model to the `Shown Layers` array.
+    * Adjust `Capture Radius` so that the target model is completely captured in all the rendered images.
+* Read the [Best Practices](#Best-Practices) to ensure that images are captured under ideal lighting and rendering conditions.
+
+### Step 2: Capturing
+
+* Use function `StartCapture()`  (`CharacterCapture.cs`) to start a capture. Chose whether or not to use the `asyncCapture` parameter:
+    * Set to `true` if the character and lighting does not change between frames. This is preferred since it avoids interrupting the UI, but you need to make sure that any dynamic effects and idle animations are disabled for the duration of the capture.
+    * Set to `false` where the character or lighting might change. The game may momentarily freeze for up to a few seconds while the images are rendered.
+* The `onCaptureFinish` will be called when Capturing is finished
+* Captured data is saved to `PROJECT_NAME/OUTPUT/Captures/`, you set the `Custom Output Path` property of the `Capturer` prefab to override this
+
+### Step 3: Uploading
+
+* Use `UploadCaptures()` (`CharacterCapture.cs`) to start uploading the data.
+    * The `onUploadSuccess` event will be called when the Upload is finished
+    * The `onUploadFailed` event will be called and give a string description on why the Upload has failed
+
+### Step 4: Checkout
+
+* After the upload is done, `onUploadSuccess` will be given a URL to the checkout page and a QR Code texture leading to the same page
+
+### Combined Capture + Upload
+
+* The event `StartCaptureAndUpload()` can be used to combine the steps for Capturing and Uploading
 
 ## Best Practices
-### Settings
-* At least 100 frames at 1024x1024 should be uploaded for best quality.
-### Mesh
-* The character mesh should take up as much space possible within the renders without cutting anything off.
-* The mesh should not have any floating pieces.
-* Meshes should not have their backfaces missing.
-### Lighting & Materials
-* Transparent materials may create artifacts within the final model so it is best not to use them if possible.
-* Having an evenly lit character will give the best results. Any shadows or lighting on the mesh will be baked into the final model.
-* Pure unlit shaders are not recommended. The meshing process needs shading to figure out the depth of points within a model.
+
+* Capture at least 100 images with resolutions of  `1024x1024` or larger.
+* Characters should occupy as much of the rendered images as possible (you may need some trial captures to test this).
+
+### Manufacturing Limitations
+
+In order to ensure that results are manufacturable:
+
+* Avoid models with disconnected or floating components
+* Ensure mesh back-faces are not missing
+* Materials should be opaque and diffuse. Transparent or reflective materials should be replaced with similar non-reflective equivalents.
+
+### Lighting
+
+* Unlit shading is not recommended; the meshing process needs shading to figure out the depth of points within a model.
+* Uniform lighting with minimal shadows is recommended, since any shadows present in images will impact model quality and may be baked into the final reconstruction.
+    * This is especially important for simple models with large uniform surfaces
 * Recommended:
     * Lit shaders with ambient lighting
     * Lit shaders with fixed lights evenly around character
     * Unlit shaders with strong ambient occlusion
 * Materials with high roughness and little specular are recommended.
     * Highly specular and highly metallic materials will create artifacts within the final model.
-* Lighting is even more important on simple, stylized characters, as any shadows baked on are a lot more noticeable.
 
-<p align="center">
-<img src="https://github.com/In-Game-Collectables/IGC_Unity2021/assets/35625367/efab12b6-946e-4895-bd84-4a9d530ff68a" width="512" height="256">
-<img src="https://github.com/In-Game-Collectables/IGC_Unity2021/assets/35625367/84cd22ed-6767-4901-9bfd-4b7bb670a4d6" width="512" height="256">
- <p align="center">Not Ideal vs. Ideal Lighting</p>
-</p>
+### Shadows (left) vs Ideal Lighting (right)
+
+![pigeon](https://github.com/In-Game-Collectables/IGC_Unity2021_URP/assets/35625367/efab12b6-946e-4895-bd84-4a9d530ff68a)
+
+![robot](https://github.com/In-Game-Collectables/IGC_Unity2021_URP/assets/35625367/84cd22ed-6767-4901-9bfd-4b7bb670a4d6)
 
 ### Ideal Lighting Examples
-<p align="center">
 
 ![pigeon](https://github.com/In-Game-Collectables/IGC_UE4/assets/35625367/13398085-397f-43d2-8756-01e94a8c5d3d)
 
@@ -69,20 +75,8 @@ This plugin will capture renders spun around a character and export out a JSON f
 
 ![mushroom](https://github.com/In-Game-Collectables/IGC_UE4/assets/35625367/1604f6ef-7124-40d0-9a0d-7403ae29ded6)
 
-</p>
-
-[Pigeon](https://sketchfab.com/3d-models/pigeon-quirky-series-e607ed34d37d433496d5a557c8230b28)
-
-[Robot](https://sketchfab.com/3d-models/robot-4-b0c5f2f5ac04402dad029d6516d706b9)
-
-[Mushroom](https://sketchfab.com/3d-models/cuute-mushroom-ffc370ddc6d542d590b9f503d0892ce0)
-
-<br />
-
 ## Notes
-The variable *CurrentStage* on the *Capturer* can be used to see if it is currently Capturing, Uploading, CheckingOut, or not doing anything.
-
-<br />
+The variable `CurrentStage` on the `Capturer` can be used to determine whether the current capture state is `Capturing`, `Uploading`, `CheckingOut`, or `None` (idle).
 
 ## Support
 Join the [Discord](https://discord.gg/JP2fEh4cNP) for any questions, feedback or even just a chat! (ﾉ◕ヮ◕)ﾉ*:･ﾟ✧


### PR DESCRIPTION
This addresses some obvious issues and puts the repository in a state to support Unity plugin development.

* A 1.0.0 tag has been set on the `main` branch to capture the state of the repository before any changes. The plugin was more or less functional in that state.
* Readme re-worded for clarity, and all inline HTML tags were removed or replaced
* Default properties of the `Capturer` prefab were set so that the plugin captures images OOB
* Changelog added